### PR TITLE
Remove explicit dialect to allow keywords

### DIFF
--- a/pyexcel/io/csvbook.py
+++ b/pyexcel/io/csvbook.py
@@ -55,7 +55,7 @@ class CSVBook:
             self.mysheets = {"csv":[]}
             # no content let's return'
             return
-        reader = csv.reader(f, dialect=csv.excel, **keywords)
+        reader = csv.reader(f, **keywords)
         longest_row_length = -1
         for row in reader:
             myrow = []


### PR DESCRIPTION
The dialect specified is the default, so it is unnecessary to provide it. Allowing `keywords` to include `dialect` enables the easy construction and registration of additional (e.g. `dialect='excel-tab'`) readers and writers.

Now the following is easy to perform:

```
pyexcel.io.READERS['tsv'] = partial(pyexcel.io.csvbook.CSVBook, dialect='excel-tab')
merge_all_to_a_book(glob.glob('*.tsv'), 'out.xls')
```
