### PR TITLE
Fix dependencies

### DIFF
--- a/.moban.d/requirements.txt
+++ b/.moban.d/requirements.txt
@@ -1,3 +1,0 @@
-{% for dependency in dependencies: %}
-{{dependency}}
-{% endfor %}

--- a/.moban.d/travis.yml
+++ b/.moban.d/travis.yml
@@ -12,6 +12,9 @@ python:
 matrix:
   include:
     - python: 2.7
+      env: MINREQ=1
+
+    - python: 2.7
       dist: trusty
       sudo: required
       virtualenv:

--- a/.moban.yml
+++ b/.moban.yml
@@ -8,7 +8,8 @@ targets:
   - setup.py: setup.py
   - "doc/source/conf.py": "docs/source/conf.py"
   - .travis.yml: travis.yml
-  - requirements.txt: requirements.txt
+  - requirements.txt: requirements.txt.jj2
+  - min_requirements.txt: min_requirements.txt.jj2
   - "tests/requirements.txt": "tests/requirements.txt"
   - LICENSE: LICENSE.jj2
   - MANIFEST.in: MANIFEST.in.jj2

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ python:
 matrix:
   include:
     - python: 2.7
+      env: MINREQ=1
+
+    - python: 2.7
       dist: trusty
       sudo: required
       virtualenv:
@@ -33,11 +36,13 @@ matrix:
             - python-mock
             - python-wheel
 before_install:
-  - if [[ $TRAVIS_PYTHON_VERSION == "pypy" || $TRAVIS_PYTHON_VERSION == "pypy3" ]]; then rm tests/test_examples.py; fi
-  - if [[ -f rnd_requirements.txt ]]; then
-      pip install --upgrade "setuptools==17.1" "pip==7.1" ;
-      pip install -r rnd_requirements.txt ;
+  - if [[ $TRAVIS_PYTHON_VERSION == "pypy" ]]; then rm tests/test_examples.py; fi
+  - if [[ -f min_requirements.txt && "$MINREQ" -eq 1 ]]; then
+      mv min_requirements.txt requirements.txt ;
     fi
+  - test ! -f rnd_requirements.txt || pip install --upgrade "setuptools" "pip==7.1"
+  - test ! -f rnd_requirements.txt || pip install --no-deps -r rnd_requirements.txt
+  - test ! -f rnd_requirements.txt || pip install -r rnd_requirements.txt ;
   - pip install -r tests/requirements.txt
 script:
   make test

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -1,5 +1,5 @@
-pyexcel-io>=0.2.0
-texttable>=0.8.2
+pyexcel-io==0.2.0
+texttable==0.8.3
 ordereddict;python_version<"2.7"
 weakrefset;python_version<"2.7"
 lxml==3.4.4;platform_python_implementation=="PyPy"

--- a/pyexcel.yml
+++ b/pyexcel.yml
@@ -3,7 +3,7 @@ name: "pyexcel"
 nick_name: pyexcel
 version: 0.2.2
 dependencies:
-  - pyexcel-io>=0.1.0
+  - pyexcel-io>=0.2.0
   - texttable>=0.8.2
   - ordereddict;python_version<"2.7"
   - weakrefset;python_version<"2.7"

--- a/rnd_requirements.txt
+++ b/rnd_requirements.txt
@@ -1,3 +1,4 @@
+.
 https://github.com/pyexcel/pyexcel-io/archive/master.zip
 https://github.com/jayvdb/pyexcel-xls/archive/use-sid.zip
 https://github.com/pyexcel/pyexcel-xlsx/archive/master.zip

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ KEYWORDS = [
 ]
 
 INSTALL_REQUIRES = [
-    'pyexcel-io>=0.1.0',
+    'pyexcel-io>=0.2.0',
     'texttable>=0.8.2',
 ]
 


### PR DESCRIPTION
Fixes #46

Previously, pyexcel installed pyexcel-text[master], which
installed pyexcel>=0.2.0, which was tested.

Previously, pyexcel specified that it depended on pyexcel-io 0.1.0,
where as it actually depends on pyexcel-io 0.2.0.

Add a MINREQ mode that verifies that the minimum requirements work.