### PR TITLE
Include LICENSE in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE
 include README.rst
 include CHANGELOG.rst


### PR DESCRIPTION
For the [conda-forge recipe](https://github.com/conda-forge/staged-recipes/pull/4105), I would like to include a hard-link to the LICENSE. 
Doing this requires having an explicit reference to LICENSE in the manifest so it can be bundled with the source.