### PR TITLE
remove leading and trailing whitespace for names

### DIFF
--- a/pyexcel/sheet.py
+++ b/pyexcel/sheet.py
@@ -632,6 +632,7 @@ def make_names_unique(alist):
     for item in alist:
         if not compact.is_string(type(item)):
             item = str(item)
+        item = item.strip()
         if item in duplicates:
             duplicates[item] = duplicates[item] + 1
             new_names.append("%s-%d" % (item, duplicates[item]))


### PR DESCRIPTION
The names will be used as keys for returned dictionary. If keys are not
striped and user inputs striped keys because excel shows unseen
whitespace, it will cause an error.