### PR TITLE
dynamically resize the table matrix on set_value

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ pyexcel - Let you focus on data, instead of file formats
 .. image:: https://raw.githubusercontent.com/pyexcel/pyexcel.github.io/master/images/patreon.png
    :target: https://www.patreon.com/chfw
 
-.. image:: https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
+.. image:: https://raw.githubusercontent.com/pyexcel/pyexcel-mobans/master/images/awesome-badge.svg
    :target: https://awesome-python.com/#specific-formats-processing
 
 .. image:: https://travis-ci.org/pyexcel/pyexcel.svg?branch=master
@@ -21,7 +21,7 @@ pyexcel - Let you focus on data, instead of file formats
    :target: https://anaconda.org/conda-forge/pyexcel
 
 .. image:: https://pepy.tech/badge/pyexcel/month
-   :target: https://pepy.tech/project/pyexcel/month
+   :target: https://pepy.tech/project/pyexcel
 
 .. image:: https://anaconda.org/conda-forge/pyexcel/badges/downloads.svg
    :target: https://anaconda.org/conda-forge/pyexcel
@@ -59,6 +59,8 @@ Known constraints
 ==================
 
 Fonts, colors and charts are not supported.
+
+Nor to read password protected xls, xlsx and ods files.
 
 Introduction
 ================================================================================

--- a/pyexcel/internal/sheets/matrix.py
+++ b/pyexcel/internal/sheets/matrix.py
@@ -82,14 +82,14 @@ class Matrix(SheetMeta):
         :param int column: column index which starts from 0
         :param any new_value: new value if this is to set the value
         """
-        fits = row < self.number_of_rows() and column < self.number_of_columns()
+        fit = row < self.number_of_rows() and column < self.number_of_columns()
         if new_value is None:
-            if fits:
+            if fit:
                 return self.__array[row][column]
             else:
                 raise IndexError("Index out of range")
         else:
-            if not fits:
+            if not fit:
                 _width, self.__array = uniform(self.__array, row+1, column+1)
 
             self.__array[row][column] = new_value

--- a/pyexcel/internal/sheets/matrix.py
+++ b/pyexcel/internal/sheets/matrix.py
@@ -82,13 +82,14 @@ class Matrix(SheetMeta):
         :param int column: column index which starts from 0
         :param any new_value: new value if this is to set the value
         """
+        fits = row < self.number_of_rows() and column < self.number_of_columns()
         if new_value is None:
-            if row < self.number_of_rows() and column < self.number_of_columns():
+            if fits:
                 return self.__array[row][column]
             else:
                 raise IndexError("Index out of range")
         else:
-            if row >= self.number_of_rows() or column >= self.number_of_columns():
+            if not fits:
                 _width, self.__array = uniform(self.__array, row+1, column+1)
 
             self.__array[row][column] = new_value
@@ -795,16 +796,16 @@ def longest_row_number(array):
         return 0
 
 
-def uniform(array, row_no=0, column_no=0):
+def uniform(array, min_rows=0, min_columns=0):
     """Fill-in empty strings to empty cells to make it MxN
 
     :param list in_array: a list of arrays
     :param int row_no: desired minimum row count
     :param int column_no: desired minimum column length
     """
-    width = max(column_no, longest_row_number(array))
+    width = max(min_columns, longest_row_number(array))
     array_length = len(array)
-    height = max(array_length, row_no)
+    height = max(array_length, min_rows)
 
     if width == 0:
         return 0, array

--- a/pyexcel/internal/sheets/matrix.py
+++ b/pyexcel/internal/sheets/matrix.py
@@ -90,7 +90,7 @@ class Matrix(SheetMeta):
                 raise IndexError("Index out of range")
         else:
             if not fit:
-                _width, self.__array = uniform(self.__array, row+1, column+1)
+                self.__width, self.__array = uniform(self.__array, row+1, column+1)
 
             self.__array[row][column] = new_value
 

--- a/pyexcel/internal/sheets/matrix.py
+++ b/pyexcel/internal/sheets/matrix.py
@@ -82,18 +82,16 @@ class Matrix(SheetMeta):
         :param int column: column index which starts from 0
         :param any new_value: new value if this is to set the value
         """
-        if row < self.number_of_rows() and column < self.number_of_columns():
-            if new_value is None:
-                # get
+        if new_value is None:
+            if row < self.number_of_rows() and column < self.number_of_columns():
                 return self.__array[row][column]
             else:
-                # set
-                self.__array[row][column] = new_value
-        else:
-            if new_value is None:
                 raise IndexError("Index out of range")
-            else:
-                self.paste((row, column), [[new_value]])
+        else:
+            if row >= self.number_of_rows() or column >= self.number_of_columns():
+                _width, self.__array = uniform(self.__array, row+1, column+1)
+
+            self.__array[row][column] = new_value
 
     def row_at(self, index):
         """
@@ -797,12 +795,17 @@ def longest_row_number(array):
         return 0
 
 
-def uniform(array):
+def uniform(array, row_no=0, column_no=0):
     """Fill-in empty strings to empty cells to make it MxN
 
     :param list in_array: a list of arrays
+    :param int row_no: desired minimum row count
+    :param int column_no: desired minimum column length
     """
-    width = longest_row_number(array)
+    width = max(column_no, longest_row_number(array))
+    array_length = len(array)
+    height = max(array_length, row_no)
+
     if width == 0:
         return 0, array
     else:
@@ -813,6 +816,9 @@ def uniform(array):
                     row[index] = constants.DEFAULT_NA
             if row_length < width:
                 row += [constants.DEFAULT_NA] * (width - row_length)
+        for _ in range(array_length, height):
+            row = [constants.DEFAULT_NA] * width
+            array.append(row)
         return width, array
 
 

--- a/pyexcel/internal/sheets/matrix.py
+++ b/pyexcel/internal/sheets/matrix.py
@@ -90,7 +90,8 @@ class Matrix(SheetMeta):
                 raise IndexError("Index out of range")
         else:
             if not fit:
-                self.__width, self.__array = uniform(self.__array, row+1, column+1)
+                width, array = uniform(self.__array, row+1, column+1)
+                self.__width, self.__array = width, array
 
             self.__array[row][column] = new_value
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ EXTRAS_REQUIRE = {
 PUBLISH_COMMAND = "{0} setup.py sdist bdist_wheel upload -r pypi".format(sys.executable)
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-GS_COMMAND = ("gs pyexcel v0.6.6 " +
+GS_COMMAND = ("gease pyexcel v0.6.6 " +
               "Find 0.6.6 in changelog for more details")
 NO_GS_MESSAGE = ("Automatic github release is disabled. " +
                  "Please install gease to enable it.")

--- a/tests/base.py
+++ b/tests/base.py
@@ -64,12 +64,18 @@ def create_sample_file2_in_memory(file_type):
     return io
 
 
+<<<<<<< Updated upstream
 class PyexcelSheetBase(unittest.TestCase):
     filename = "fixtures/non-uniform-rows.csv"
 
+=======
+class PyexcelSheetBase():
+>>>>>>> Stashed changes
     def setUp(self):
-        filename = os.path.join(os.path.dirname(__file__), self.filename)
-        self.sheet = pe.get_sheet(file_name=filename)
+        self.sheet = pe.Sheet([
+            [f"{row_no}_{col_no}" for col_no in range(10)]
+            for row_no in range(10)
+        ])
 
 
 class PyexcelBase:

--- a/tests/base.py
+++ b/tests/base.py
@@ -63,6 +63,14 @@ def create_sample_file2_in_memory(file_type):
     return io
 
 
+class SheetBaseTestcase():
+    filename = "fixtures/non-uniform-rows.csv"
+
+    def setUp(self):
+        filename = os.path.join(os.path.dirname(__file__), self.filename)
+        self.sheet = pyexcel.get_sheet(file_name=filename)
+
+
 class PyexcelBase:
     def _write_test_file(self, filename):
         """

--- a/tests/base.py
+++ b/tests/base.py
@@ -63,7 +63,7 @@ def create_sample_file2_in_memory(file_type):
     return io
 
 
-class SheetBaseTestcase():
+class PyexcelSheetBase():
     filename = "fixtures/non-uniform-rows.csv"
 
     def setUp(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -68,7 +68,7 @@ class SheetBaseTestcase():
 
     def setUp(self):
         filename = os.path.join(os.path.dirname(__file__), self.filename)
-        self.sheet = pyexcel.get_sheet(file_name=filename)
+        self.sheet = pe.get_sheet(file_name=filename)
 
 
 class PyexcelBase:

--- a/tests/base.py
+++ b/tests/base.py
@@ -64,13 +64,9 @@ def create_sample_file2_in_memory(file_type):
     return io
 
 
-<<<<<<< Updated upstream
 class PyexcelSheetBase(unittest.TestCase):
     filename = "fixtures/non-uniform-rows.csv"
 
-=======
-class PyexcelSheetBase():
->>>>>>> Stashed changes
     def setUp(self):
         self.sheet = pe.Sheet([
             [f"{row_no}_{col_no}" for col_no in range(10)]

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,7 @@ import json
 
 import pyexcel as pe
 
+import unittest
 from nose.tools import eq_, raises
 
 
@@ -63,7 +64,7 @@ def create_sample_file2_in_memory(file_type):
     return io
 
 
-class PyexcelSheetBase():
+class PyexcelSheetBase(unittest.TestCase):
     filename = "fixtures/non-uniform-rows.csv"
 
     def setUp(self):

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -1,0 +1,25 @@
+import unittest
+from nose.tools import eq_, raises
+
+import pyexcel
+import random
+
+class SheetAccessTest(unittest.TestCase):
+    filename = "fixtures/non-uniform-rows.csv"
+
+    def setUp(self):
+        self.sheet = pyexcel.get_sheet(file_name=self.filename)
+
+    @staticmethod
+    def get_random_char():
+        i = random.randint(97, 122)
+        return chr(i)
+
+    def test_out_of_bounds_access(self):
+        value = self.get_random_char()
+        column = self.get_random_char() + self.get_random_char()
+        cell = column + str(random.randint(1, 30))
+        self.sheet[cell] = value
+
+        self.assertEqual(value, self.sheet[cell])
+    

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -23,7 +23,7 @@ class TestSheetAccess(PyexcelSheetBase):
 
         with self.assertRaises(IndexError):
             self.sheet[20, 0]
-        
+
     def test_column_edge_case(self):
         column = self.sheet.number_of_columns()-1
 

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -1,15 +1,10 @@
-import unittest
-
 import pyexcel
 import random
 
+from base import SheetBaseTestcase
 
-class SheetAccessTest(unittest.TestCase):
-    filename = "fixtures/non-uniform-rows.csv"
 
-    def setUp(self):
-        self.sheet = pyexcel.get_sheet(file_name=self.filename)
-
+class SheetAccessTest(SheetBaseTestcase):
     @staticmethod
     def get_random_char():
         i = random.randint(97, 122)

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -1,18 +1,25 @@
 import random
 
-from base import SheetBaseTestcase
+from base import PyexcelSheetBase
 
 
-class SheetAccessTest(SheetBaseTestcase):
+class SheetAccessTest(PyexcelSheetBase):
     @staticmethod
     def get_random_char():
         i = random.randint(97, 122)
         return chr(i)
 
-    def test_out_of_bounds_access(self):
+    def test_out_of_bounds_write(self):
         value = self.get_random_char()
         column = self.get_random_char() + self.get_random_char()
         cell = column + str(random.randint(1, 30))
         self.sheet[cell] = value
 
         self.assertEqual(value, self.sheet[cell])
+
+    def test_out_of_bounds_read(self):
+        with self.assertRaises(IndexError):
+            self[0, 20]
+
+        with self.assertRaises(IndexError):
+            self[20, 0]

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -1,8 +1,8 @@
 import unittest
-from nose.tools import eq_, raises
 
 import pyexcel
 import random
+
 
 class SheetAccessTest(unittest.TestCase):
     filename = "fixtures/non-uniform-rows.csv"
@@ -22,4 +22,3 @@ class SheetAccessTest(unittest.TestCase):
         self.sheet[cell] = value
 
         self.assertEqual(value, self.sheet[cell])
-    

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -19,7 +19,7 @@ class TestSheetAccess(PyexcelSheetBase):
 
     def test_out_of_bounds_read(self):
         with self.assertRaises(IndexError):
-            self[0, 20]
+            self.sheet[0, 20]
 
         with self.assertRaises(IndexError):
-            self[20, 0]
+            self.sheet[20, 0]

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -1,4 +1,3 @@
-import pyexcel
 import random
 
 from base import SheetBaseTestcase

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -23,3 +23,17 @@ class TestSheetAccess(PyexcelSheetBase):
 
         with self.assertRaises(IndexError):
             self.sheet[20, 0]
+        
+    def test_column_edge_case(self):
+        column = self.sheet.number_of_columns()-1
+
+        self.assertEqual(self.sheet[0, column], f"0_{column}")
+        with self.assertRaises(IndexError):
+            self.sheet[0, column+1]
+
+    def test_row_edge_case(self):
+        row = self.sheet.number_of_rows()-1
+
+        self.assertEqual(self.sheet[row, 0], f"{row}_0")
+        with self.assertRaises(IndexError):
+            self.sheet[row+1, 0]

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -3,7 +3,7 @@ import random
 from base import PyexcelSheetBase
 
 
-class SheetAccessTest(PyexcelSheetBase):
+class TestSheetAccess(PyexcelSheetBase):
     @staticmethod
     def get_random_char():
         i = random.randint(97, 122)


### PR DESCRIPTION
I will conform to pr checklist later.

here is a use case:
``` python
sheet=pyexcel.Sheet()
sheet[1,1] = "JO"
sheet["AA1"] = "test"
```

that leads to an index error.
I think it is a valid use case to set arbitrary cells at random positions?

This pr adds arguments to uniform so we can make an array of min_width and min_height

```

---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-2-df6d362a346f> in <module>
      1 sheet=pyexcel.Sheet()
      2 sheet[1,1] = "JO"
----> 3 sheet["AA1"] = "test"

~/dev/pyexcel/pyexcel/sheet.py in __setitem__(self, aset, c)
    607             self.cell_value(row, column, c)
    608         else:
--> 609             Matrix.__setitem__(self, aset, c)
    610 
    611     def __len__(self):

~/dev/pyexcel/pyexcel/internal/sheets/matrix.py in __setitem__(self, aset, cell_value)
    467         elif isinstance(aset, str):
    468             row, column = utils.excel_cell_position(aset)
--> 469             return self.cell_value(row, column, cell_value)
    470         else:
    471             raise IndexError

~/dev/pyexcel/pyexcel/internal/sheets/matrix.py in cell_value(self, row, column, new_value)
     94                 raise IndexError("Index out of range")
     95             else:
---> 96                 self.paste((row, column), [[new_value]])
     97 
     98     def row_at(self, index):

~/dev/pyexcel/pyexcel/internal/sheets/matrix.py in paste(self, topleft_corner, rows, columns)
    405         """
    406         if rows:
--> 407             self._paste_rows(topleft_corner, rows)
    408         elif columns:
    409             self._paste_columns(topleft_corner, columns)

~/dev/pyexcel/pyexcel/internal/sheets/matrix.py in _paste_rows(self, topleft_corner, rows)
    427             set_index = starting_row + index
    428             if set_index < number_of_rows:
--> 429                 self._set_row_at(set_index, row, starting=topleft_corner[1])
    430             else:
    431                 real_row = [constants.DEFAULT_NA] * topleft_corner[1] + row

~/dev/pyexcel/pyexcel/internal/sheets/matrix.py in _set_row_at(self, row_index, data_array, starting)
    153             self.__width, self.__array = uniform(self.__array)
    154         else:
--> 155             raise IndexError(constants.MESSAGE_INDEX_OUT_OF_RANGE)
    156 
    157     def _extend_row(self, row):
```

With your PR, here is a check list:

- [ ] Has test cases written?
- [ ] Has all code lines tested?
- [ ] Has `make format` been run?
- [ ] Please update CHANGELOG.yml(not CHANGELOG.rst)
- [ ] Passes all Travis CI builds
- [ ] Has fair amount of documentation if your change is complex
- [x] Agree on NEW BSD License for your contribution
