### PR TITLE
cleanup setup.py & tests

### DIFF
--- a/pyexcel/__version__.py
+++ b/pyexcel/__version__.py
@@ -1,2 +1,2 @@
-__version__ = '0.7.0'
-__author__ = 'C.W.'
+__version__ = "0.7.0"
+__author__ = "C.W."

--- a/pyexcel/docstrings/core.py
+++ b/pyexcel/docstrings/core.py
@@ -9,7 +9,6 @@
 """
 from . import keywords
 
-
 __GET_ARRAY__ = (
     keywords.SOURCE_PARAMS_TABLE
     + """
@@ -18,10 +17,7 @@ __GET_ARRAY__ = (
     + keywords.SOURCE_PARAMS
 )
 
-__GET_SHEET__ = (
-    keywords.EXAMPLE_NOTE_PAGINATION
-    + __GET_ARRAY__
-)
+__GET_SHEET__ = keywords.EXAMPLE_NOTE_PAGINATION + __GET_ARRAY__
 
 __GET_BOOK__ = (
     keywords.SOURCE_BOOK_PARAMS_TABLE

--- a/pyexcel/internal/sheets/_shared.py
+++ b/pyexcel/internal/sheets/_shared.py
@@ -80,7 +80,7 @@ def excel_cell_position(pos_chars: str) -> Tuple[int, int]:
     match = re.match("([A-Za-z]+)([0-9]+)", pos_chars)
 
     if match:
-        return int(match.group(2)) - 1, _get_index(match.group(1).upper())
+        return int(match.group(2)) - 1, excel_column_index(match.group(1))
     else:
         raise IndexError(f"invalid index: {pos_chars}")
 
@@ -93,9 +93,9 @@ INDEX_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 INDEX_BASE = len(INDEX_CHARS)
 
 
-def _get_index(index_chars: str) -> int:
+def excel_column_index(index_chars: str) -> int:
     index = -1
-    for i, char in enumerate(index_chars[::-1]):
+    for i, char in enumerate(index_chars.upper()[::-1]):
         # going from right to left, the multiplicator is:
         # 26^0 = 1
         # 26^1 = 26

--- a/pyexcel/internal/sheets/_shared.py
+++ b/pyexcel/internal/sheets/_shared.py
@@ -93,13 +93,13 @@ INDEX_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 INDEX_BASE = len(INDEX_CHARS)
 
 
-def _get_index(index_chars: str) -> int:    
+def _get_index(index_chars: str) -> int:
     index = -1
     for i, char in enumerate(index_chars[::-1]):
         # going from right to left, the multiplicator is:
         # 26^0 = 1
         # 26^1 = 26
-        index += (1+INDEX_CHARS.index(char)) * INDEX_BASE ** i
+        index += (1 + INDEX_CHARS.index(char)) * INDEX_BASE**i
 
     return index
 

--- a/pyexcel/internal/sheets/_shared.py
+++ b/pyexcel/internal/sheets/_shared.py
@@ -9,6 +9,7 @@
 """
 import re
 import types
+from typing import Tuple
 from functools import partial
 
 from pyexcel._compact import PY2
@@ -71,47 +72,36 @@ def analyse_slice(aslice, upper_bound):
     return my_range
 
 
-def excel_column_index(index_chars):
-    """translate MS excel column position to index"""
-    if len(index_chars) < 1:
-        return -1
-    else:
-        return _get_index(index_chars.upper())
+def excel_cell_position(pos_chars: str) -> Tuple[int, int]:
+    """
+    translate MS excel position to index
+    Return: (row: int, column: int)
+    """
+    match = re.match("([A-Za-z]+)([0-9]+)", pos_chars)
 
-
-def excel_cell_position(pos_chars):
-    """translate MS excel position to index"""
-    if len(pos_chars) < 2:
-        return -1, -1
-    group = re.match("([A-Za-z]+)([0-9]+)", pos_chars)
-    if group:
-        return int(group.group(2)) - 1, excel_column_index(group.group(1))
+    if match:
+        return int(match.group(2)) - 1, _get_index(match.group(1).upper())
     else:
-        raise IndexError
+        raise IndexError(f"invalid index: {pos_chars}")
 
 
 """
 In order to easily compute the actual index of 'X' or 'AX', these utility
 functions were written
 """
-_INDICES = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+INDEX_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+INDEX_BASE = len(INDEX_CHARS)
 
 
-def _get_index(index_chars):
-    length = len(index_chars)
-    index_chars_length = len(_INDICES)
-    if length > 1:
-        index = 0
-        for i in range(0, length):
-            if i < (length - 1):
-                index += (_INDICES.index(index_chars[i]) + 1) * (
-                    index_chars_length ** (length - 1 - i)
-                )
-            else:
-                index += _INDICES.index(index_chars[i])
-        return index
-    else:
-        return _INDICES.index(index_chars[0])
+def _get_index(index_chars: str) -> int:    
+    index = -1
+    for i, char in enumerate(index_chars[::-1]):
+        # going from right to left, the multiplicator is:
+        # 26^0 = 1
+        # 26^1 = 26
+        index += (1+INDEX_CHARS.index(char)) * INDEX_BASE ** i
+
+    return index
 
 
 def names_to_indices(names, series):

--- a/pyexcel/internal/sheets/_shared.py
+++ b/pyexcel/internal/sheets/_shared.py
@@ -82,7 +82,7 @@ def excel_cell_position(pos_chars: str) -> Tuple[int, int]:
     if match:
         return int(match.group(2)) - 1, excel_column_index(match.group(1))
     else:
-        raise IndexError(f"invalid index: {pos_chars}")
+        raise KeyError(f"invalid index: {pos_chars}")
 
 
 """

--- a/pyexcel/internal/sheets/matrix.py
+++ b/pyexcel/internal/sheets/matrix.py
@@ -12,6 +12,7 @@ import copy
 import types
 from functools import partial
 from itertools import chain
+from typing import Tuple
 
 from pyexcel import _compact as compact
 from pyexcel import constants as constants
@@ -22,6 +23,8 @@ from pyexcel.internal.sheets.formatters import to_format
 from pyexcel.internal.sheets.extended_list import PyexcelList
 
 from . import _shared as utils
+
+MatrixIndex = Tuple[int, int] | str
 
 
 class Matrix(SheetMeta):
@@ -460,29 +463,29 @@ class Matrix(SheetMeta):
                         del self.__array[i][j]
             self.__width = longest_row_number(self.__array)
 
-    def __setitem__(self, aset, cell_value):
+    def __setitem__(self, index: MatrixIndex, cell_value):
         """Override the operator to set items"""
-        if isinstance(aset, tuple):
-            return self.cell_value(aset[0], aset[1], cell_value)
-        elif isinstance(aset, str):
-            row, column = utils.excel_cell_position(aset)
+        if isinstance(index, tuple):
+            return self.cell_value(index[0], index[1], cell_value)
+        elif isinstance(index, str):
+            row, column = utils.excel_cell_position(index)
             return self.cell_value(row, column, cell_value)
-        else:
-            raise IndexError
 
-    def __getitem__(self, aset):
+        raise IndexError
+
+    def __getitem__(self, index: MatrixIndex):
         """By default, this class recognize from top to bottom
         from left to right"""
-        if isinstance(aset, tuple):
-            return self.cell_value(aset[0], aset[1])
-        elif isinstance(aset, str):
-            row, column = utils.excel_cell_position(aset)
+        if isinstance(index, tuple):
+            return self.cell_value(index[0], index[1])
+        elif isinstance(index, str):
+            row, column = utils.excel_cell_position(index)
             return self.cell_value(row, column)
-        elif isinstance(aset, int):
+        elif isinstance(index, int):
             print(constants.MESSAGE_DEPRECATED_ROW_COLUMN)
-            return self.row_at(aset)
-        else:
-            raise IndexError
+            return self.row_at(index)
+        
+        raise IndexError
 
     def contains(self, predicate):
         """Has something in the table"""

--- a/pyexcel/internal/sheets/matrix.py
+++ b/pyexcel/internal/sheets/matrix.py
@@ -10,9 +10,9 @@
 """
 import copy
 import types
+from typing import Tuple, Union
 from functools import partial
 from itertools import chain
-from typing import Tuple
 
 from pyexcel import _compact as compact
 from pyexcel import constants as constants
@@ -24,7 +24,7 @@ from pyexcel.internal.sheets.extended_list import PyexcelList
 
 from . import _shared as utils
 
-MatrixIndex = Tuple[int, int] | str
+MatrixIndex = Union[Tuple[int, int], str]
 
 
 class Matrix(SheetMeta):
@@ -484,7 +484,7 @@ class Matrix(SheetMeta):
         elif isinstance(index, int):
             print(constants.MESSAGE_DEPRECATED_ROW_COLUMN)
             return self.row_at(index)
-        
+
         raise IndexError
 
     def contains(self, predicate):

--- a/pyexcel/internal/source_plugin.py
+++ b/pyexcel/internal/source_plugin.py
@@ -53,7 +53,7 @@ class SourcePluginManager(PluginManager):
         return plugin
 
     def register_a_plugin(self, plugin_cls, plugin_info):
-        """ for dynamically loaded plugin """
+        """for dynamically loaded plugin"""
         PluginManager.register_a_plugin(self, plugin_cls, plugin_info)
         self._register_a_plugin_info(plugin_info)
 

--- a/pyexcel/renderer.py
+++ b/pyexcel/renderer.py
@@ -144,6 +144,7 @@ class BinaryRenderer(Renderer):
     """
     Renderer pyexcel data into a binary object
     """
+
     WRITE_FLAG = "wb"
 
     def get_io(self):

--- a/pyexcel/sheet.py
+++ b/pyexcel/sheet.py
@@ -593,7 +593,7 @@ class Sheet(Matrix):
                 column = aset[1]
             return self.cell_value(row, column)
         else:
-            return Matrix.__getitem__(self, aset)
+            return super().__getitem__(aset)
 
     def __setitem__(self, aset, c):
         if isinstance(aset, tuple):
@@ -608,7 +608,7 @@ class Sheet(Matrix):
                 column = aset[1]
             self.cell_value(row, column, c)
         else:
-            Matrix.__setitem__(self, aset, c)
+            super().__setitem__(aset, c)
 
     def __len__(self):
         return self.number_of_rows()

--- a/pyexcel/sheet.py
+++ b/pyexcel/sheet.py
@@ -356,7 +356,7 @@ class Sheet(Matrix):
             Matrix.delete_columns(self, [index])
 
     def named_row_at(self, name):
-        """Get a row by its name """
+        """Get a row by its name"""
         index = name
         index = self.rownames.index(name)
         row_array = self.row_at(index)

--- a/setup.py
+++ b/setup.py
@@ -6,29 +6,9 @@ Template by pypi-mobans
 
 import os
 import sys
-import codecs
-import locale
-import platform
 from shutil import rmtree
 
 from setuptools import Command, setup, find_packages
-
-PY2 = sys.version_info[0] == 2
-PY26 = PY2 and sys.version_info[1] < 7
-PY33 = sys.version_info < (3, 4)
-
-# Work around mbcs bug in distutils.
-# http://bugs.python.org/issue10945
-# This work around is only if a project supports Python < 3.4
-
-# Work around for locale not being set
-try:
-    lc = locale.getlocale()
-    pf = platform.system()
-    if pf != "Windows" and lc == (None, None):
-        locale.setlocale(locale.LC_ALL, "C.UTF-8")
-except (ValueError, UnicodeError, locale.Error):
-    locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 
 NAME = "pyexcel"
 AUTHOR = "C.W."
@@ -41,7 +21,7 @@ DESCRIPTION = (
 )
 URL = "https://github.com/pyexcel/pyexcel"
 DOWNLOAD_URL = "%s/archive/0.7.0.tar.gz" % URL
-FILES = ["README.rst", "CONTRIBUTORS.rst", "CHANGELOG.rst"]
+README_FILES = ["README.rst", "CONTRIBUTORS.rst", "CHANGELOG.rst"]
 KEYWORDS = [
     "python",
     'tsv',
@@ -155,17 +135,14 @@ def has_gease():
 
 def read_files(*files):
     """Read files into setup"""
-    text = ""
-    for single_file in files:
-        content = read(single_file)
-        text = text + content + "\n"
-    return text
+    return "\n".join([read(filename) for filename in files])
 
 
-def read(afile):
+def read(filename):
     """Read a file into setup"""
-    the_relative_file = os.path.join(HERE, afile)
-    with codecs.open(the_relative_file, "r", "utf-8") as opened_file:
+    filename_absolute = os.path.join(HERE, filename)
+
+    with open(filename_absolute) as opened_file:
         content = filter_out_test_code(opened_file)
         content = "".join(list(content))
         return content
@@ -205,7 +182,7 @@ if __name__ == "__main__":
         description=DESCRIPTION,
         url=URL,
         download_url=DOWNLOAD_URL,
-        long_description=read_files(*FILES),
+        long_description=read_files(*README_FILES),
         license=LICENSE,
         keywords=KEYWORDS,
         python_requires=PYTHON_REQUIRES,
@@ -216,5 +193,5 @@ if __name__ == "__main__":
         include_package_data=True,
         zip_safe=False,
         classifiers=CLASSIFIERS,
-        cmdclass=SETUP_COMMANDS
+        #cmdclass=SETUP_COMMANDS
     )

--- a/setup.py
+++ b/setup.py
@@ -193,5 +193,5 @@ if __name__ == "__main__":
         include_package_data=True,
         zip_safe=False,
         classifiers=CLASSIFIERS,
-        #cmdclass=SETUP_COMMANDS
+        cmdclass=SETUP_COMMANDS
     )

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -7,9 +7,9 @@ from textwrap import dedent
 
 import psutil
 import pyexcel as p
-from ._compact import StringIO, OrderedDict
 
 from nose.tools import eq_
+from ._compact import StringIO, OrderedDict
 
 
 def test_bug_01():
@@ -166,7 +166,7 @@ def test_issue_51_normal_dict_in_records():
 
 
 def test_issue_55_unicode_in_headers():
-    headers = [u"Äkkilähdöt", u"Matkakirjoituksia", u"Matkatoimistot"]
+    headers = ["Äkkilähdöt", "Matkakirjoituksia", "Matkatoimistot"]
     content = [headers, [1, 2, 3]]
     sheet = p.Sheet(content)
     sheet.name_columns_by_row(0)
@@ -566,7 +566,7 @@ def test_issue_241():
     +---------+---------+---+---------+"""
     ).lstrip()
     eq_(str(book), expected)
-    os.unlink('issue_241.xlsx')
+    os.unlink("issue_241.xlsx")
 
 
 def test_issue_250():

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import psutil
 import pyexcel as p
-from _compact import StringIO, OrderedDict
+from ._compact import StringIO, OrderedDict
 
 from nose.tools import eq_
 

--- a/tests/test_cookbook.py
+++ b/tests/test_cookbook.py
@@ -1,7 +1,7 @@
 import os
 
 import pyexcel as pe
-from base import clean_up_files
+from .base import clean_up_files
 
 from nose.tools import eq_, raises
 

--- a/tests/test_cookbook.py
+++ b/tests/test_cookbook.py
@@ -1,9 +1,9 @@
 import os
 
 import pyexcel as pe
-from .base import clean_up_files
 
 from nose.tools import eq_, raises
+from .base import clean_up_files
 
 
 class TestSpliting:
@@ -12,7 +12,7 @@ class TestSpliting:
         self.content4 = {
             "Sheet1": [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]],
             "Sheet2": [[4, 4, 4, 4], [5, 5, 5, 5], [6, 6, 6, 6]],
-            "Sheet3": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]],
+            "Sheet3": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]],
         }
         pe.save_book_as(dest_file_name=self.testfile4, bookdict=self.content4)
 
@@ -87,7 +87,7 @@ class TestCookbook:
         self.content4 = {
             "Sheet1": [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]],
             "Sheet2": [[4, 4, 4, 4], [5, 5, 5, 5], [6, 6, 6, 6]],
-            "Sheet3": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]],
+            "Sheet3": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]],
         }
         pe.save_book_as(dest_file_name=self.testfile4, bookdict=self.content4)
 

--- a/tests/test_django_related_functions.py
+++ b/tests/test_django_related_functions.py
@@ -1,5 +1,5 @@
 import pyexcel as pe
-from _compact import OrderedDict
+from ._compact import OrderedDict
 
 from nose.tools import eq_, raises
 

--- a/tests/test_django_related_functions.py
+++ b/tests/test_django_related_functions.py
@@ -1,7 +1,7 @@
 import pyexcel as pe
-from ._compact import OrderedDict
 
 from nose.tools import eq_, raises
+from ._compact import OrderedDict
 
 
 class Attributable:
@@ -187,10 +187,10 @@ class TestBook:
     def setUp(self):
         self.content = OrderedDict()
         self.content.update(
-            {"Sheet1": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
+            {"Sheet1": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
         )
         self.content.update(
-            {"Sheet2": [[u"A", u"B", u"C"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
+            {"Sheet2": [["A", "B", "C"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
         )
         self.result1 = [
             {"Y": 4, "X": 1, "Z": 7},
@@ -223,9 +223,7 @@ class TestBook:
 
     def test_model_save_to_models(self):
         model = FakeDjangoModel("Sheet1")
-        data = {
-            "Sheet1": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]
-        }
+        data = {"Sheet1": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
         pe.save_book_as(dest_models=[model, None, None], bookdict=data)
         assert model.objects.objs == self.result1
 
@@ -235,7 +233,7 @@ class TestBook:
         # with an exception.
         model = FakeDjangoModel("Sheet1")
         book = pe.Book(
-            {"Sheet1": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
+            {"Sheet1": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
         )
         book.save_to_django_models([model])
         assert model.objects.objs == self.result1

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -42,7 +42,7 @@ class TestAllExamples:
                     fn(path)
 
 
-class TestPyexcelServer(TestCase):
+class x(TestCase):
     """
     This test tells how difficult to test unicode vs bytes when
     dealing with csv files in relation to pyexcel. and this

--- a/tests/test_file_type_as_attribute.py
+++ b/tests/test_file_type_as_attribute.py
@@ -3,11 +3,11 @@ from textwrap import dedent
 
 from pyexcel import Book, Sheet, get_book
 from pyexcel import constants as constants
-from ._compact import StringIO, OrderedDict
 from pyexcel.source import AbstractSource, MemorySourceMixin
 from pyexcel.plugins import SourceInfo
 
 from nose.tools import eq_, raises
+from ._compact import StringIO, OrderedDict
 
 FIXTURE = "dummy"
 

--- a/tests/test_file_type_as_attribute.py
+++ b/tests/test_file_type_as_attribute.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 
 from pyexcel import Book, Sheet, get_book
 from pyexcel import constants as constants
-from _compact import StringIO, OrderedDict
+from ._compact import StringIO, OrderedDict
 from pyexcel.source import AbstractSource, MemorySourceMixin
 from pyexcel.plugins import SourceInfo
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,7 +1,7 @@
 import datetime
 from unittest import TestCase
 
-from base import clean_up_files
+from .base import clean_up_files
 from pyexcel import SeriesReader, save_as, get_sheet
 from pyexcel.internal.sheets import formatters
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,9 +1,10 @@
 import datetime
 from unittest import TestCase
 
-from .base import clean_up_files
 from pyexcel import SeriesReader, save_as, get_sheet
 from pyexcel.internal.sheets import formatters
+
+from .base import clean_up_files
 
 
 def increase_func(x):

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -2,7 +2,7 @@ import os
 import copy
 import datetime
 
-from base import PyexcelIteratorBase, create_sample_file2
+from .base import PyexcelIteratorBase, create_sample_file2
 from pyexcel import Reader, SeriesReader, save_as, get_sheet
 from pyexcel.internal.sheets import Matrix, _shared
 

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -440,7 +440,7 @@ class TestUtilityFunctions(unittest.TestCase):
         chars = "Z"
         index = _shared.excel_column_index(chars)
         self.assertEqual(index, 25)
-        
+
         chars = "AB"
         index = _shared.excel_column_index(chars)
         self.assertEqual(index, 27)
@@ -452,8 +452,8 @@ class TestUtilityFunctions(unittest.TestCase):
     def test_excel_cell_position(self):
         with self.assertRaises(KeyError):
             row, column = _shared.excel_cell_position("A")
-            
-        self.assertEqual(_shared.excel_cell_position("A1"), (0,0))
+
+        self.assertEqual(_shared.excel_cell_position("A1"), (0, 0))
         self.assertEqual(_shared.excel_cell_position("Z1"), (0, 25))
         self.assertEqual(_shared.excel_cell_position("AA1"), (0, 26))
         self.assertEqual(_shared.excel_cell_position("AAB111"), (110, 703))
@@ -462,13 +462,13 @@ class TestUtilityFunctions(unittest.TestCase):
         a = slice(None, 3)
         bound = 4
 
-        self.assertEqual(_shared.analyse_slice(a, bound), [0,1,2])
-        
+        self.assertEqual(_shared.analyse_slice(a, bound), [0, 1, 2])
+
         a = slice(1, None)
         bound = 4
         expected = [1, 2, 3]
         self.assertEqual(_shared.analyse_slice(a, bound), expected)
-        
+
         a = slice(2, 1)  # invalid series
         bound = 4
 

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -2,11 +2,11 @@ import os
 import copy
 import datetime
 
-from .base import PyexcelIteratorBase, create_sample_file2
 from pyexcel import Reader, SeriesReader, save_as, get_sheet
 from pyexcel.internal.sheets import Matrix, _shared
 
 from nose.tools import eq_, raises
+from .base import PyexcelIteratorBase, create_sample_file2
 
 
 class TestMatrixColumn:

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -295,7 +295,7 @@ class TestMatrixRow:
             assert 1 == 1
 
 
-class TestMatrix:
+class TestMatrix(unittest.TestCase):
     def setUp(self):
         self.data = [
             ["a", "b", "c", "d"],
@@ -306,26 +306,27 @@ class TestMatrix:
     def test_empty_array_input(self):
         """Test empty array as input to Matrix"""
         m = Matrix([])
-        assert m.number_of_columns() == 0
-        assert m.number_of_rows() == 0
+        self.assertEqual(m.number_of_columns(), 0)
+        self.assertEqual(m.number_of_rows(), 0)
 
     def test_update_a_cell(self):
         r = Matrix(self.data)
         r[0, 0] = "k"
-        assert r[0, 0] == "k"
+        self.assertEqual(r[0, 0], "k")
+        
         d = datetime.date(2014, 10, 1)
         r.cell_value(0, 1, d)
-        assert isinstance(r[0, 1], datetime.date) is True
-        assert r[0, 1].strftime("%d/%m/%y") == "01/10/14"
+        self.assertTrue(isinstance(r[0, 1], datetime.date))
+        self.assertEqual(r[0, 1].strftime("%d/%m/%y"), "01/10/14")
         r["A1"] = "p"
-        assert r[0, 0] == "p"
+        self.assertEqual(r[0, 0], "p")
         r[0, 1] = 16
-        assert r["B1"] == 16
+        self.assertEqual(r["B1"], 16)
 
     def test_old_style_access(self):
         r = Matrix(self.data)
         r[0, 0] = "k"
-        assert r[0][0] == "k"
+        self.assertEqual(r[0][0], "k")
 
     def test_wrong_index_type(self):
         r = Matrix(self.data)
@@ -342,7 +343,7 @@ class TestMatrix:
         result = [[1, 4], [2, 5], [3, 6]]
         m = Matrix(data)
         m.transpose()
-        eq_(result, m.get_internal_array())
+        self.assertEqual(result, m.get_internal_array())
 
     def test_set_column_at(self):
         r = Matrix(self.data)
@@ -352,10 +353,10 @@ class TestMatrix:
         except IndexError:
             assert 1 == 1
 
-    @raises(IndexError)
     def test_delete_rows_with_invalid_list(self):
         m = Matrix([])
-        m.delete_rows("ab")  # bang, cannot delete
+        with self.assertRaises(IndexError):
+            m.delete_rows("ab")  # bang, cannot delete
 
 
 class TestIteratableArray(PyexcelIteratorBase):

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -327,15 +327,15 @@ class TestMatrix:
         r[0, 0] = "k"
         assert r[0][0] == "k"
 
-    @raises(IndexError)
     def test_wrong_index_type(self):
         r = Matrix(self.data)
-        r["string"][0]  # bang, cannot get
+        with self.assertRaises(KeyError):
+            r["string"][0]  # bang, cannot get
 
-    @raises(IndexError)
-    def test_wrong_index_type2(self):
+    def test_wrong_index_type_set(self):
         r = Matrix(self.data)
-        r["string"] = "k"  # bang, cannot set
+        with self.assertRaises(KeyError):
+            r["string"] = "k"  # bang, cannot set
 
     def test_transpose(self):
         data = [[1, 2, 3], [4, 5, 6]]

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -1,6 +1,7 @@
 import os
 import copy
 import datetime
+import unittest
 
 from pyexcel import Reader, SeriesReader, save_as, get_sheet
 from pyexcel.internal.sheets import Matrix, _shared
@@ -429,47 +430,47 @@ class TestHatIterators:
             os.unlink(self.testfile)
 
 
-class TestUtilityFunctions:
+class TestUtilityFunctions(unittest.TestCase):
     def test_excel_column_index(self):
         chars = ""
         index = _shared.excel_column_index(chars)
-        assert index == -1
+
+        self.assertEqual(index, -1)
+
         chars = "Z"
         index = _shared.excel_column_index(chars)
-        assert index == 25
+        self.assertEqual(index, 25)
+        
         chars = "AB"
         index = _shared.excel_column_index(chars)
-        assert index == 27
+        self.assertEqual(index, 27)
+
         chars = "AAB"
         index = _shared.excel_column_index(chars)
-        eq_(index, 703)
+        self.assertEqual(index, 703)
 
     def test_excel_cell_position(self):
-        pos_chars = "A"
-        row, column = _shared.excel_cell_position(pos_chars)
-        assert row == -1
-        assert column == -1
-        pos_chars = "A1"
-        row, column = _shared.excel_cell_position(pos_chars)
-        assert row == 0
-        assert column == 0
-        pos_chars = "AAB111"
-        row, column = _shared.excel_cell_position(pos_chars)
-        assert row == 110
-        eq_(column, 703)
+        with self.assertRaises(KeyError):
+            row, column = _shared.excel_cell_position("A")
+            
+        self.assertEqual(_shared.excel_cell_position("A1"), (0,0))
+        self.assertEqual(_shared.excel_cell_position("Z1"), (0, 25))
+        self.assertEqual(_shared.excel_cell_position("AA1"), (0, 26))
+        self.assertEqual(_shared.excel_cell_position("AAB111"), (110, 703))
 
-    @raises(ValueError)
     def test_analyse_slice(self):
         a = slice(None, 3)
         bound = 4
-        expected = [0, 1, 2]
-        result = _shared.analyse_slice(a, bound)
-        assert expected == result
+
+        self.assertEqual(_shared.analyse_slice(a, bound), [0,1,2])
+        
         a = slice(1, None)
         bound = 4
         expected = [1, 2, 3]
-        result = _shared.analyse_slice(a, bound)
-        assert expected == result
+        self.assertEqual(_shared.analyse_slice(a, bound), expected)
+        
         a = slice(2, 1)  # invalid series
         bound = 4
-        result = _shared.analyse_slice(a, bound)  # bang
+
+        with self.assertRaises(ValueError):
+            result = _shared.analyse_slice(a, bound)  # bang

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -313,7 +313,7 @@ class TestMatrix(unittest.TestCase):
         r = Matrix(self.data)
         r[0, 0] = "k"
         self.assertEqual(r[0, 0], "k")
-        
+
         d = datetime.date(2014, 10, 1)
         r.cell_value(0, 1, d)
         self.assertTrue(isinstance(r[0, 1], datetime.date))

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -473,4 +473,4 @@ class TestUtilityFunctions(unittest.TestCase):
         bound = 4
 
         with self.assertRaises(ValueError):
-            result = _shared.analyse_slice(a, bound)  # bang
+            _shared.analyse_slice(a, bound)  # bang

--- a/tests/test_multiple_sheets.py
+++ b/tests/test_multiple_sheets.py
@@ -1,10 +1,10 @@
 import os
 
 import pyexcel as pe
-from .base import PyexcelMultipleSheetBase, clean_up_files, create_sample_file1
-from ._compact import OrderedDict
 
 from nose.tools import eq_, raises
+from .base import PyexcelMultipleSheetBase, clean_up_files, create_sample_file1
+from ._compact import OrderedDict
 
 
 class TestXlsNXlsmMultipleSheets(PyexcelMultipleSheetBase):
@@ -509,9 +509,9 @@ class TestMergeCSVsIntoOne:
             [1, 2, 3],
             [4, 5, 6],
             [7, 8, 9],
-            [u"a", u"b", u"c"],
-            [u"d", u"e", u"f"],
-            [u"g", u"h", u"i"],
+            ["a", "b", "c"],
+            ["d", "e", "f"],
+            ["g", "h", "i"],
             [1.1, 2.2, 3.3],
             [4.4, 5.5, 6.6],
             [7.7, 8.8, 9.9],
@@ -529,6 +529,6 @@ def _produce_ordered_dict():
     data_dict.update({"Sheet1": [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]]})
     data_dict.update({"Sheet2": [[4, 4, 4, 4], [5, 5, 5, 5], [6, 6, 6, 6]]})
     data_dict.update(
-        {"Sheet3": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
+        {"Sheet3": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
     )
     return data_dict

--- a/tests/test_multiple_sheets.py
+++ b/tests/test_multiple_sheets.py
@@ -1,8 +1,8 @@
 import os
 
 import pyexcel as pe
-from base import PyexcelMultipleSheetBase, clean_up_files, create_sample_file1
-from _compact import OrderedDict
+from .base import PyexcelMultipleSheetBase, clean_up_files, create_sample_file1
+from ._compact import OrderedDict
 
 from nose.tools import eq_, raises
 

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -22,7 +22,7 @@ class TestPresentation(TestCase):
         self.assertEqual(str(s), content)
 
     def test_irregular_usage(self):
-        """textable doesn't like empty string """
+        """textable doesn't like empty string"""
         content = [[1, 2, 3], [4, 588, 6], [7, 8]]  # one empty string
         s = pe.Sheet(content)
         content = dedent(

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,12 +1,12 @@
 import pyexcel as p
+
+from nose.tools import eq_, raises
 from .base import (
     PyexcelBase,
     clean_up_files,
     create_generic_file,
     create_sample_file1,
 )
-
-from nose.tools import eq_, raises
 
 
 class TestReader:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,5 +1,5 @@
 import pyexcel as p
-from base import (
+from .base import (
     PyexcelBase,
     clean_up_files,
     create_generic_file,

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,4 +1,3 @@
-from ._compact import BytesIO
 from pyexcel.renderer import (
     Renderer,
     DbRenderer,
@@ -7,6 +6,7 @@ from pyexcel.renderer import (
 )
 
 from nose.tools import raises
+from ._compact import BytesIO
 
 
 @raises(NotImplementedError)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,4 +1,4 @@
-from _compact import BytesIO
+from ._compact import BytesIO
 from pyexcel.renderer import (
     Renderer,
     DbRenderer,

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -10,12 +10,7 @@ class TestSheetAccess(PyexcelSheetBase):
     def get_random_char():
         i = random.randint(97, 122)
         return chr(i)
-
-    def test_excel_index(self):
-        self.assertEqual(excel_cell_position("A1"), (0, 0))
-        self.assertEqual(excel_cell_position("Z1"), (0, 25))
-        self.assertEqual(excel_cell_position("AA1"), (0, 26))
-
+        
     def test_out_of_bounds_write(self):
         value = self.get_random_char()
         column = self.get_random_char() + self.get_random_char()

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -1,7 +1,5 @@
 import random
 
-from pyexcel.internal.sheets._shared import excel_cell_position
-
 from .base import PyexcelSheetBase
 
 

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -1,6 +1,9 @@
 import random
 
-from base import PyexcelSheetBase
+from .base import PyexcelSheetBase
+
+
+from pyexcel.internal.sheets._shared import excel_cell_position
 
 
 class TestSheetAccess(PyexcelSheetBase):
@@ -8,6 +11,11 @@ class TestSheetAccess(PyexcelSheetBase):
     def get_random_char():
         i = random.randint(97, 122)
         return chr(i)
+
+    def test_excel_index(self):
+        self.assertEqual(excel_cell_position("A1"), (0, 0))
+        self.assertEqual(excel_cell_position("Z1"), (0, 25))
+        self.assertEqual(excel_cell_position("AA1"), (0, 26))
 
     def test_out_of_bounds_write(self):
         value = self.get_random_char()

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -1,9 +1,8 @@
 import random
 
-from .base import PyexcelSheetBase
-
-
 from pyexcel.internal.sheets._shared import excel_cell_position
+
+from .base import PyexcelSheetBase
 
 
 class TestSheetAccess(PyexcelSheetBase):

--- a/tests/test_sheet_access.py
+++ b/tests/test_sheet_access.py
@@ -10,7 +10,7 @@ class TestSheetAccess(PyexcelSheetBase):
     def get_random_char():
         i = random.randint(97, 122)
         return chr(i)
-        
+
     def test_out_of_bounds_write(self):
         value = self.get_random_char()
         column = self.get_random_char() + self.get_random_char()

--- a/tests/test_sheet_column.py
+++ b/tests/test_sheet_column.py
@@ -1,5 +1,7 @@
 import unittest
+
 from pyexcel import Sheet
+
 from ._compact import OrderedDict
 
 
@@ -11,7 +13,7 @@ class TestSheetColumn(unittest.TestCase):
             [4, 5, 6],
             [7, 8, 9],
         ]
-    
+
     def test_negative_row_index(self):
         s = Sheet(self.data, "test")
         data = s.column[-1]
@@ -37,9 +39,9 @@ class TestSheetColumn(unittest.TestCase):
         s.name_columns_by_row(0)
         data = OrderedDict({"Column 4": [10, 11, 12]})
         s1 = s.column + data
-        
+
         self.assertEqual(s1.column.Column_4, [10, 11, 12])
-        
+
         # check that we don't have the column in the original sheet
         with self.assertRaises((AttributeError)):
             self.assertEqual(s.column.Column_4, [10, 11, 12])
@@ -125,7 +127,10 @@ class TestSheetColumn2(unittest.TestCase):
         custom_columns = ["C1", "C2", "C3"]
         with self.assertRaises((NotImplementedError)):
             Sheet(
-                self.data, "test", colnames=custom_columns, name_columns_by_row=0
+                self.data,
+                "test",
+                colnames=custom_columns,
+                name_columns_by_row=0,
             )
 
     def test_formatter_by_named_column(self):

--- a/tests/test_sheet_column.py
+++ b/tests/test_sheet_column.py
@@ -1,10 +1,9 @@
+import unittest
 from pyexcel import Sheet
-from _compact import OrderedDict
-
-from nose.tools import eq_, raises, assert_not_in
+from ._compact import OrderedDict
 
 
-class TestSheetColumn:
+class TestSheetColumn(unittest.TestCase):
     def setUp(self):
         self.data = [
             ["Column 1", "Column 2", "Column 3"],
@@ -12,91 +11,94 @@ class TestSheetColumn:
             [4, 5, 6],
             [7, 8, 9],
         ]
-
+    
     def test_negative_row_index(self):
         s = Sheet(self.data, "test")
         data = s.column[-1]
-        eq_(data, ["Column 3", 3, 6, 9])
+        self.assertEqual(data, ["Column 3", 3, 6, 9])
 
     def test_formatter_by_named_column(self):
         """Test one named column"""
         s = Sheet(self.data, "test")
         s.name_columns_by_row(0)
         s.column.format("Column 1", str)
-        eq_(s.column["Column 1"], ["1", "4", "7"])
+        self.assertEqual(s.column["Column 1"], ["1", "4", "7"])
 
     def test_formatter_by_named_columns(self):
         """Test multiple named columns"""
         s = Sheet(self.data, "test")
         s.name_columns_by_row(0)
         s.column.format(["Column 1", "Column 3"], str)
-        eq_(s.column["Column 1"], ["1", "4", "7"])
-        eq_(s.column["Column 3"], ["3", "6", "9"])
+        self.assertEqual(s.column["Column 1"], ["1", "4", "7"])
+        self.assertEqual(s.column["Column 3"], ["3", "6", "9"])
 
-    @raises(AttributeError)
     def test_add(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(0)
         data = OrderedDict({"Column 4": [10, 11, 12]})
         s1 = s.column + data
-        eq_(s1.column.Column_4, [10, 11, 12])
-        eq_(s.column.Column_4, [10, 11, 12])
+        
+        self.assertEqual(s1.column.Column_4, [10, 11, 12])
+        
+        # check that we don't have the column in the original sheet
+        with self.assertRaises((AttributeError)):
+            self.assertEqual(s.column.Column_4, [10, 11, 12])
 
     def test_iadd(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(0)
         data = OrderedDict({"Column 4": [10, 11, 12]})
         s.column += data
-        eq_(s.column.Column_4, [10, 11, 12])
+        self.assertEqual(s.column.Column_4, [10, 11, 12])
 
-    @raises(TypeError)
     def test_add_wrong_type(self):
         """Add string type"""
         s = Sheet(self.data, "test")
         s.name_columns_by_row(0)
-        s = s.column + "string type"  # bang
+        with self.assertRaises((TypeError)):
+            s = s.column + "string type"  # bang
 
-    @raises(ValueError)
     def test_delete_named_column(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(0)
         del s.column["Column 2"]
         assert s.number_of_columns() == 2
-        s.column["Column 2"]  # bang
+        with self.assertRaises((ValueError)):
+            s.column["Column 2"]  # bang
 
-    @raises(ValueError)
     def test_delete_indexed_column1(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(0)
         del s.column[1]
         assert s.number_of_columns() == 2
-        s.column["Column 2"]  # access it after deletion, bang
+        with self.assertRaises((ValueError)):
+            s.column["Column 2"]  # access it after deletion, bang
 
-    @raises(ValueError)
     def test_delete_indexed_column2(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(0)
         del s.column["Column 2"]
         assert s.number_of_columns() == 2
-        s.column["Column 2"]  # access it after deletion, bang
+        with self.assertRaises((ValueError)):
+            s.column["Column 2"]  # access it after deletion, bang
 
-    @raises(ValueError)
     def test_delete_indexed_column(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(0)
         s.delete_named_column_at(1)
         assert s.number_of_columns() == 2
-        s.column["Column 2"]  # access it after deletion, bang
+        with self.assertRaises((ValueError)):
+            s.column["Column 2"]  # access it after deletion, bang
 
-    @raises(ValueError)
     def test_delete_column(self):
         s = Sheet(self.data, "test")
         del s.column[1, 2]
         assert s.number_of_columns() == 1
-        s.column["Column 2"]  # access it after deletion, bang
+        with self.assertRaises((ValueError)):
+            s.column["Column 2"]  # access it after deletion, bang
 
 
-class TestSheetColumn2:
+class TestSheetColumn2(unittest.TestCase):
     def setUp(self):
         self.data = [
             [1, 2, 3],
@@ -108,65 +110,63 @@ class TestSheetColumn2:
     def test_series(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(2)
-        eq_(s.colnames, ["Column 1", "Column 2", "Column 3"])
+        self.assertEqual(s.colnames, ["Column 1", "Column 2", "Column 3"])
         custom_columns = ["C1", "C2", "C3"]
         s.colnames = custom_columns
-        eq_(s.colnames, custom_columns)
+        self.assertEqual(s.colnames, custom_columns)
 
     def test_series2(self):
         custom_columns = ["C1", "C2", "C3"]
         s = Sheet(self.data, "test", colnames=custom_columns)
-        assert s.colnames == custom_columns
 
-    @raises(NotImplementedError)
+        self.assertEqual(s.colnames, custom_columns)
+
     def test_series3(self):
         custom_columns = ["C1", "C2", "C3"]
-        Sheet(
-            self.data, "test", colnames=custom_columns, name_columns_by_row=0
-        )
+        with self.assertRaises((NotImplementedError)):
+            Sheet(
+                self.data, "test", colnames=custom_columns, name_columns_by_row=0
+            )
 
     def test_formatter_by_named_column(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(2)
         s.column.format("Column 1", str)
-        assert s.column["Column 1"] == ["1", "4", "7"]
-
-    def test_formatter_by_named_column_2(self):
-        s = Sheet(self.data, "test")
-        s.name_columns_by_row(2)
-        s.column.format("Column 1", str)
-        assert s.column["Column 1"] == ["1", "4", "7"]
+        self.assertEqual(s.column["Column 1"], ["1", "4", "7"])
 
     def test_add(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(2)
         data = OrderedDict({"Column 4": [10, 11, 12]})
         s1 = s.column + data
-        eq_(s1.column["Column 4"], [10, 11, 12])
-        assert_not_in("Column 4", s.column)
+        self.assertEqual(s1.column["Column 4"], [10, 11, 12])
+
+        self.assertNotIn("Column 4", s.column)
 
     def test_iadd(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(2)
         data = OrderedDict({"Column 4": [10, 11, 12]})
         s.column += data
-        assert s.column["Column 4"] == [10, 11, 12]
+
+        self.assertEqual(s.column["Column 4"], [10, 11, 12])
 
     def test_dot_notation(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(2)
-        eq_(s.column.Column_3, [3, 6, 9])
+        self.assertEqual(s.column.Column_3, [3, 6, 9])
 
-    @raises(ValueError)
     def test_delete_named_column(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(2)
         del s.column["Column 2"]
         assert s.number_of_columns() == 2
-        s.column["Column 2"]  # bang
+        with self.assertRaises((ValueError)):
+            s.column["Column 2"]  # bang
 
     def test_set_indexed_row(self):
         s = Sheet(self.data, "test")
         s.name_columns_by_row(2)
         s.row[0] = [10000, 1, 11]
-        assert s.row[0] == [10000, 1, 11]
+
+        self.assertEqual(s.row[0], [10000, 1, 11])

--- a/tests/test_sheet_row.py
+++ b/tests/test_sheet_row.py
@@ -1,7 +1,7 @@
 from pyexcel import Sheet
-from ._compact import OrderedDict
 
 from nose.tools import eq_, raises, assert_not_in
+from ._compact import OrderedDict
 
 
 class TestSheetRow:

--- a/tests/test_sheet_row.py
+++ b/tests/test_sheet_row.py
@@ -1,5 +1,5 @@
 from pyexcel import Sheet
-from _compact import OrderedDict
+from ._compact import OrderedDict
 
 from nose.tools import eq_, raises, assert_not_in
 

--- a/tests/test_sheet_update.py
+++ b/tests/test_sheet_update.py
@@ -1,4 +1,6 @@
 import pyexcel as pe
+
+from nose.tools import eq_, raises
 from .base import (
     PyexcelSheetRWBase,
     clean_up_files,
@@ -6,8 +8,6 @@ from .base import (
     create_sample_file1_series,
 )
 from ._compact import OrderedDict
-
-from nose.tools import eq_, raises
 
 
 class TestReader:

--- a/tests/test_sheet_update.py
+++ b/tests/test_sheet_update.py
@@ -1,11 +1,11 @@
 import pyexcel as pe
-from base import (
+from .base import (
     PyexcelSheetRWBase,
     clean_up_files,
     create_sample_file1,
     create_sample_file1_series,
 )
-from _compact import OrderedDict
+from ._compact import OrderedDict
 
 from nose.tools import eq_, raises
 

--- a/tests/test_signature_fuction.py
+++ b/tests/test_signature_fuction.py
@@ -2,8 +2,8 @@ import os
 from types import GeneratorType
 
 import pyexcel as pe
-from db import Base, Session, Signature, Signature2, engine
-from _compact import OrderedDict
+from .db import Base, Session, Signature, Signature2, engine
+from ._compact import OrderedDict
 
 from nose.tools import eq_, raises
 

--- a/tests/test_signature_fuction.py
+++ b/tests/test_signature_fuction.py
@@ -2,10 +2,10 @@ import os
 from types import GeneratorType
 
 import pyexcel as pe
-from .db import Base, Session, Signature, Signature2, engine
-from ._compact import OrderedDict
 
 from nose.tools import eq_, raises
+from .db import Base, Session, Signature, Signature2, engine
+from ._compact import OrderedDict
 
 
 def test_unknown_file_type_exception():
@@ -772,7 +772,7 @@ def _produce_ordered_dict():
     data_dict.update({"Sheet1": [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]]})
     data_dict.update({"Sheet2": [[4, 4, 4, 4], [5, 5, 5, 5], [6, 6, 6, 6]]})
     data_dict.update(
-        {"Sheet3": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
+        {"Sheet3": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
     )
     return data_dict
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -3,9 +3,9 @@ from textwrap import dedent
 from unittest import TestCase
 
 import pyexcel as pe
-from .db import Base, Pyexcel, Session, engine
 
 from nose.tools import eq_, raises
+from .db import Base, Pyexcel, Session, engine
 
 
 class TestSQL(TestCase):

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 from unittest import TestCase
 
 import pyexcel as pe
-from db import Base, Pyexcel, Session, engine
+from .db import Base, Pyexcel, Session, engine
 
 from nose.tools import eq_, raises
 

--- a/tests/test_stringio.py
+++ b/tests/test_stringio.py
@@ -2,8 +2,8 @@ import os
 import sys
 
 import pyexcel as pe
-from base import create_sample_file1
-from _compact import BytesIO
+from .base import create_sample_file1
+from ._compact import BytesIO
 
 from nose.tools import eq_, raises
 

--- a/tests/test_stringio.py
+++ b/tests/test_stringio.py
@@ -2,10 +2,10 @@ import os
 import sys
 
 import pyexcel as pe
-from .base import create_sample_file1
-from ._compact import BytesIO
 
 from nose.tools import eq_, raises
+from .base import create_sample_file1
+from ._compact import BytesIO
 
 
 def do_read_stringio(file_name):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,9 +22,9 @@ class TestToRecord(TestCase):
     def test_book_reader_to_records(self):
         r = pe.SeriesReader(self.testfile)
         result = [
-            {u"Y": 4.0, u"X": 1.0, u"Z": 7.0},
-            {u"Y": 5.0, u"X": 2.0, u"Z": 8.0},
-            {u"Y": 6.0, u"X": 3.0, u"Z": 9.0},
+            {"Y": 4.0, "X": 1.0, "Z": 7.0},
+            {"Y": 5.0, "X": 2.0, "Z": 8.0},
+            {"Y": 6.0, "X": 3.0, "Z": 9.0},
         ]
         eq_(result, list(r.records))
 
@@ -57,9 +57,9 @@ class TestToRecord(TestCase):
         r = pe.SeriesReader(self.testfile)
         custom_headers = ["O", "P", "Q"]
         result = [
-            {u"P": 4.0, u"O": 1.0, u"Q": 7.0},
-            {u"P": 5.0, u"O": 2.0, u"Q": 8.0},
-            {u"P": 6.0, u"O": 3.0, u"Q": 9.0},
+            {"P": 4.0, "O": 1.0, "Q": 7.0},
+            {"P": 5.0, "O": 2.0, "Q": 8.0},
+            {"P": 6.0, "O": 3.0, "Q": 9.0},
         ]
         actual = r.to_records(custom_headers)
         eq_(result, list(actual))


### PR DESCRIPTION
This is a starter to make pyexcel safe for the future:

- nose has been deprecated. It seems best to me to translate tests to builtin unittest testcases. I did a start for that and fixed relative imports in tests
- removed some legacy python2 code in setup.py
- simplified the excel-to-column-nr code & added type hints

With your PR, here is a check list:

- [x] Has test cases written?
- [x] Has all code lines tested?
- [x] Has `make format` been run?
- [ ] Please update CHANGELOG.yml(not CHANGELOG.rst)
- [ ] Has fair amount of documentation if your change is complex
- [x] Agree on NEW BSD License for your contribution
