### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/renderers.rst
+++ b/docs/source/renderers.rst
@@ -29,7 +29,7 @@ Draw charts from your excel data
 `pyexcel-echarts`_  draws 2D, 3D, geo charts from pyexcel data and has awesome animations too, but
 it is under development.
 
-`pyexcel-matplotlib`_ helps you with scientific charts and is under developmement.
+`pyexcel-matplotlib`_ helps you with scientific charts and is under development.
 
 Gantt chart visualization for your excel data
 -------------------------------------------------

--- a/pyexcel/core.py
+++ b/pyexcel/core.py
@@ -87,7 +87,7 @@ def isave_as(**keywords):
     """
     Save a sheet from a data source to another one with less memory
 
-    It is simliar to :meth:`pyexcel.save_as` except that it does
+    It is similar to :meth:`pyexcel.save_as` except that it does
     not accept parameters for :class:`pyexcel.Sheet`. And it read
     when it writes.
     """
@@ -117,7 +117,7 @@ def isave_book_as(**keywords):
     """
     Save a book from a data source to another one
 
-    It is simliar to :meth:`pyexcel.save_book_as` but it read
+    It is similar to :meth:`pyexcel.save_book_as` but it read
     when it writes. This function provide some speedup but
     the output data is not made uniform.
     """

--- a/pyexcel/internal/meta.py
+++ b/pyexcel/internal/meta.py
@@ -173,7 +173,7 @@ class PyexcelObject(object):
             +---+
 
         Where b.stream.xls.getvalue() is equivalent to b.xls. In some situation
-        b.stream.xls is prefered than b.xls.
+        b.stream.xls is preferred than b.xls.
 
         Sheet examples::
 
@@ -187,7 +187,7 @@ class PyexcelObject(object):
             +---+
 
         Where s.stream.xls.getvalue() is equivalent to s.xls. In some situation
-        s.stream.xls is prefered than s.xls.
+        s.stream.xls is preferred than s.xls.
 
         It is similar to :meth:`~pyexcel.Book.save_to_memory`.
         """

--- a/pyexcel/internal/sheets/matrix.py
+++ b/pyexcel/internal/sheets/matrix.py
@@ -713,7 +713,7 @@ class Matrix(SheetMeta):
         Example::
 
             >>> import pyexcel as pe
-            >>> # Given a dictinoary as the following
+            >>> # Given a dictionary as the following
             >>> data = {
             ...     "1": [1, 2, 3, 4, 5, 6, 7, 8],
             ...     "3": [1.25, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8],
@@ -740,7 +740,7 @@ class Matrix(SheetMeta):
         Example::
 
             >>> import pyexcel as pe
-            >>> # Given a dictinoary as the following
+            >>> # Given a dictionary as the following
             >>> data = {
             ...     "1": [1, 2, 3, 4, 5, 6, 7, 8],
             ...     "3": [1.25, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8],

--- a/pyexcel/plugins/parsers/sqlalchemy.py
+++ b/pyexcel/plugins/parsers/sqlalchemy.py
@@ -14,7 +14,7 @@ from pyexcel_io.database import common as sql
 
 
 class SQLAlchemyExporter(DbParser):
-    """export data via sqlalchmey"""
+    """export data via sqlalchemy"""
 
     def parse_db(
         self, argument, export_columns_list=None, on_demand=False, **keywords

--- a/pyexcel/plugins/sources/db_sources.py
+++ b/pyexcel/plugins/sources/db_sources.py
@@ -90,7 +90,7 @@ class BookDbSource(AbstractSource):
         return data
 
     def get_params(self):
-        """form the paraneters for the db parser and renderer"""
+        """form the parameters for the db parser and renderer"""
         pass
 
     def get_source_info(self):

--- a/pyexcel/plugins/sources/output_to_memory.py
+++ b/pyexcel/plugins/sources/output_to_memory.py
@@ -42,7 +42,7 @@ class WriteSheetToMemory(AbstractSource, MemorySourceMixin):
 # pylint: disable=W0223
 class WriteBookToMemory(WriteSheetToMemory):
     """
-    Multiple sheet data source for writting back to memory
+    Multiple sheet data source for writing back to memory
     """
 
     def write_data(self, book):

--- a/pyexcel/sheet.py
+++ b/pyexcel/sheet.py
@@ -484,7 +484,7 @@ class Sheet(Matrix):
         Rearrange the sheet.
 
         :ivar new_ordered_columns: new columns
-        :ivar exclusion: to exlucde named column or not. defaults to False
+        :ivar exclusion: to exclude named column or not. defaults to False
 
         Example::
 
@@ -628,7 +628,7 @@ class _RepresentedString(object):
 
 
 def make_names_unique(alist):
-    """Append the number of occurences to duplicated names"""
+    """Append the number of occurrences to duplicated names"""
     duplicates = {}
     new_names = []
     for item in alist:

--- a/pyexcel/source.py
+++ b/pyexcel/source.py
@@ -59,7 +59,7 @@ class MemorySourceMixin(object):
     """
 
     def get_content(self):
-        """Get memory repsentation of the formatted data
+        """Get memory representation of the formatted data
 
         e.g. StringIO instance which contains the csv formatted data
         """


### PR DESCRIPTION
There are small typos in:
- docs/source/renderers.rst
- pyexcel/core.py
- pyexcel/internal/meta.py
- pyexcel/internal/sheets/matrix.py
- pyexcel/plugins/parsers/sqlalchemy.py
- pyexcel/plugins/sources/db_sources.py
- pyexcel/plugins/sources/output_to_memory.py
- pyexcel/sheet.py
- pyexcel/source.py

Fixes:
- Should read `similar` rather than `simliar`.
- Should read `dictionary` rather than `dictinoary`.
- Should read `sqlalchemy` rather than `sqlalchmey`.
- Should read `representation` rather than `repsentation`.
- Should read `writing` rather than `writting`.
- Should read `preferred` rather than `prefered`.
- Should read `parameters` rather than `paraneters`.
- Should read `occurrences` rather than `occurences`.
- Should read `exclude` rather than `exlucde`.
- Should read `development` rather than `developmement`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md