### PR TITLE
fix: honor negative indices in delete_rows and delete_columns

### DIFF
--- a/pyexcel/internal/sheets/matrix.py
+++ b/pyexcel/internal/sheets/matrix.py
@@ -171,10 +171,12 @@ class Matrix(SheetMeta):
         if isinstance(row_indices, list) is False:
             raise IndexError
         if len(row_indices) > 0:
+            nrows = self.number_of_rows()
+            row_indices = [i if i >= 0 else nrows + i for i in row_indices]
             unique_list = _unique(row_indices)
             sorted_list = sorted(unique_list, reverse=True)
             for i in sorted_list:
-                if i < self.number_of_rows() and i >= 0:
+                if i < nrows and i >= 0:
                     del self.__array[i]
 
     def column_at(self, index):
@@ -450,11 +452,13 @@ class Matrix(SheetMeta):
         if isinstance(column_indices, list) is False:
             raise TypeError(constants.MESSAGE_DATA_ERROR_DATA_TYPE_MISMATCH)
         if len(column_indices) > 0:
+            ncols = self.number_of_columns()
+            column_indices = [j if j >= 0 else ncols + j for j in column_indices]
             unique_list = _unique(column_indices)
             sorted_list = sorted(unique_list, reverse=True)
             for i in self.row_range():
                 for j in sorted_list:
-                    if j < self.number_of_columns() and j >= 0:
+                    if j < ncols and j >= 0:
                         del self.__array[i][j]
             self.__width = longest_row_number(self.__array)
 

--- a/pyexcel/sheet.py
+++ b/pyexcel/sheet.py
@@ -317,6 +317,8 @@ class Sheet(Matrix):
 
         :param list column_indices: a list of column indices
         """
+        ncols = len(self.__column_names) if len(self.__column_names) > 0 else self.number_of_columns()
+        column_indices = [i if i >= 0 else ncols + i for i in column_indices]
         Matrix.delete_columns(self, column_indices)
         if len(self.__column_names) > 0:
             new_series = [
@@ -331,6 +333,8 @@ class Sheet(Matrix):
 
         :param list row_indices: a list of row indices
         """
+        nrows = len(self.__row_names) if len(self.__row_names) > 0 else self.number_of_rows()
+        row_indices = [i if i >= 0 else nrows + i for i in row_indices]
         Matrix.delete_rows(self, row_indices)
         if len(self.__row_names) > 0:
             new_series = [

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -358,6 +358,19 @@ class TestMatrix(unittest.TestCase):
         with self.assertRaises(IndexError):
             m.delete_rows("ab")  # bang, cannot delete
 
+    def test_delete_rows_with_negative_index(self):
+        m = Matrix(self.data)
+        m.delete_rows([-1])
+        self.assertEqual(m.number_of_rows(), 2)
+        self.assertEqual(m.row[0], ["a", "b", "c", "d"])
+        self.assertEqual(m.row[1], ["e", "f", "g", "h"])
+
+    def test_delete_columns_with_negative_index(self):
+        m = Matrix(self.data)
+        m.delete_columns([-1])
+        self.assertEqual(m.number_of_columns(), 3)
+        self.assertEqual(m.row[0], ["a", "b", "c"])
+
 
 class TestIterator(PyexcelIteratorBase):
     def setUp(self):


### PR DESCRIPTION
## Summary

`delete_rows([-1])` and `delete_columns([-1])` silently did nothing instead of removing the last row/column.

The guard `i >= 0` in `Matrix.delete_rows` and `j >= 0` in `Matrix.delete_columns` discarded every negative index before the actual deletion. Meanwhile `row_at(-1)` and `column_at(-1)` already support negative indexing, so this was an inconsistency in the API.

**Before the fix:**
```python
import pyexcel as p

sheet = p.Sheet([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
sheet.delete_rows([-1])
print(sheet.to_array())   # [[1, 2, 3], [4, 5, 6], [7, 8, 9]]  — no change!

sheet2 = p.Sheet([['a', 'b', 'c'], [1, 2, 3]], name_columns_by_row=0)
sheet2.delete_columns([-1])
print(sheet2.colnames)    # ['a', 'b', 'c']  — unchanged!
```

**After the fix:**
```python
sheet.delete_rows([-1])
print(sheet.to_array())   # [[1, 2, 3], [4, 5, 6]]  ✓

sheet2.delete_columns([-1])
print(sheet2.colnames)    # ['a', 'b']  ✓
```

## Changes

- **`pyexcel/internal/sheets/matrix.py`**: Normalize negative indices (add `nrows` / `ncols`) in `Matrix.delete_rows` and `Matrix.delete_columns` before the bounds check.
- **`pyexcel/sheet.py`**: Apply the same normalization in `Sheet.delete_rows` and `Sheet.delete_columns` so that named row/column lists are also updated correctly.
- **`tests/test_iterator.py`**: Add `test_delete_rows_with_negative_index` and `test_delete_columns_with_negative_index` to `TestMatrix`.

This pull request was prepared with the assistance of AI, under my direction and review.